### PR TITLE
fix: the size of the footer increases the size of the screen

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -2,7 +2,7 @@
   <footer>
     <div>
       Built by <span class="title">RootstockLabs</span>
-      <div class="copy">Copyright &copy; {{ new Date().getFullYear() }} Roostock Labs. All rights reserved.</div>
+      <div class="copy">Copyright &copy; {{ new Date().getFullYear() }} Rootstock Labs. All rights reserved.</div>
     </div>
     <div>
       <ul class="navigation">

--- a/src/styles/_footer.scss
+++ b/src/styles/_footer.scss
@@ -1,11 +1,10 @@
 footer {
   color: $white_100;
-  max-width: 1350px;
-  margin: 20px auto;
   display: flex;
+  margin-top: 15px;
   justify-content: space-between;
   align-items: center;
-  padding: 12px;
+  padding: 24px;
   .title {
     font-size: 18px;
     font-weight: bold;


### PR DESCRIPTION
The size of the footer increases the size of the screen

![image](https://github.com/rsksmart/rsk-stats/assets/149804324/faf9e3ff-81a5-4e0d-89d2-c5d9f75d4581)

replace: Roostock to Rootstock
